### PR TITLE
bump base OS version for CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Ruby runtime as a parent image
-FROM ruby:3.0-slim
+FROM ruby:3-slim
 
 # Install necessary system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Docker Scout found the previous `3.0-slim` base OS had some CVEs. The `3-slim` tag tracks updated versions and is current. There are still open CVEs on this version but far fewer.