### PR TITLE
ensure env file exists; remove problematic direct-run instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY . .
 # Ensure the .env file is copied if it exists
 COPY .env* ./
 
+# Ensure the .env file exists even if blank
+RUN touch .env
+
 # Run the tests
 RUN bundle exec rspec
 

--- a/readme.md
+++ b/readme.md
@@ -58,12 +58,6 @@ Run the container using the provided script:
 ./run.sh [--repo=REPO_NAME] [--token=TOKEN] [--days=DAYS_AGO] [--debug]
 ```
 
-Or run it directly with Docker, providing arguments as needed:
-
-```
-docker run --rm -v "$(pwd)/.env:/app/.env" github-pr-report --token=your_token --repo=owner/repo --days=7 --debug
-```
-
 **The report will be printed to the console.**
 
 ## Scheduling with Cron


### PR DESCRIPTION
Add a Dockerfile instruction to touch the env file in case it was missing.
Remove the problematic option in the README to directly run the container.